### PR TITLE
Fix null values in JSON messages

### DIFF
--- a/engine/botplayer.py
+++ b/engine/botplayer.py
@@ -76,7 +76,7 @@ class BotPlayer(object):
                             for c in self.game.conns if lh.pos in c]
             lighthouses.append({
                 "position": lh.pos,
-                "owner": lh.owner,
+                "owner": lh.owner if lh.owner is not None else -1,
                 "energy": lh.energy,
                 "connections": connections,
                 "have_key": lh.pos in self.player.keys,


### PR DESCRIPTION
When a lighthouse has no owner, its value should be -1 (acording to https://github.com/marcan/lighthouses_aicontest/blob/master/aicontest_spec.txt#L151) but null values are being sent to the players.